### PR TITLE
Bump Go version to 1.24.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   #     - uses: actions/checkout@v2
   #     - uses: actions/setup-go@v2
   #       with:
-  #         go-version: '^1.16'
+  #         go-version: '^1.24.3'
   #     - uses: RyanSiu1995/kubebuilder-action@v1.2.1
   #     - run: make test
   #     - uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.17 as builder
+FROM golang:1.24.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snapp-incubator/argocd-complementary-operator
 
-go 1.17
+go 1.24.3
 
 require (
 	github.com/argoproj/argo-cd/v2 v2.0.5


### PR DESCRIPTION
This commit updates the Go version used in your project to 1.24.3.

The following files were modified:
- go.mod: Updated Go version directive.
- Dockerfile: Updated base image to use golang:1.24.3.
- .github/workflows/ci.yml: Updated Go version for CI pipeline.