### PR TITLE
fix: wire cluster-admin-teams ConfigMap into manager env

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,6 +32,9 @@ spec:
           envFrom:
             - configMapRef:
                 name: public-repos
+            - configMapRef:
+                name: cluster-admin-teams
+                optional: true
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Problem
`createAppProj` reads `os.Getenv("CLUSTER_ADMIN_TEAMS")` to decide whether a team's AppProject gets `ClusterResourceWhitelist: */*` (cluster admin) instead of `ClusterResourceBlacklist: */*`. But the manager Deployment only mounted the `public-repos` ConfigMap via `envFrom` — so `CLUSTER_ADMIN_TEAMS` was **never supplied**, and every team (including those listed as cluster admins, e.g. `box` on box-teh-2) fell into the blacklist branch. This blocks CRDs/ClusterRoles (AWX, Strimzi, …) from syncing.

## Fix
Add an `envFrom` reference to the `cluster-admin-teams` ConfigMap (rendered per-cluster by the snappcloud/helm `argocd-complementary` chart). Marked `optional: true` so clusters that don't define cluster-admin teams keep working.

Verified `kubectl kustomize config/default` renders both envFrom entries; the external `cluster-admin-teams` name stays literal (matches the helm-created ConfigMap) despite the namePrefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)