### PR TITLE
test: fix goconst lint issues (extract repeated literals)

### DIFF
--- a/internal/controller/argocduser_controller_test.go
+++ b/internal/controller/argocduser_controller_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-cm` ConfigMap and create required accounts", func() {
 			var expectedKey string
 			cm := &corev1.ConfigMap{}
-			lookup := types.NamespacedName{Name: "argocd-cm", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdCM, Namespace: argocdAppsNs}
 
 			// TODO: Enhance this
 			By("Verifying argocd-cm is updated with accounts.<ACCOUNT-admin>")
@@ -196,7 +196,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-secret` Secret and create required accounts", func() {
 			var expectedKey string
 			sec := &corev1.Secret{}
-			lookup := types.NamespacedName{Name: "argocd-secret", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdSecret, Namespace: argocdAppsNs}
 
 			// Check for admin CI account
 			By("Verifying argocd-secret is updated with accounts.<ACCOUNT-admin>.password")
@@ -379,7 +379,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-cm` ConfigMap and delete required accounts", func() {
 			By("Verifying admin account is removed from argocd-cm")
 			cm := &corev1.ConfigMap{}
-			lookup := types.NamespacedName{Name: "argocd-cm", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdCM, Namespace: argocdAppsNs}
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookup, cm)).To(Succeed())
@@ -392,7 +392,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-secret` Secret and delete required accounts", func() {
 			By("Verifying passwords are removed from argocd-secret")
 			sec := &corev1.Secret{}
-			lookup := types.NamespacedName{Name: "argocd-secret", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdSecret, Namespace: argocdAppsNs}
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookup, sec)).To(Succeed())
@@ -567,7 +567,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-cm` ConfigMap and update required accounts", func() {
 			By("Verifying accounts still exist in argocd-cm")
 			cm := &corev1.ConfigMap{}
-			lookup := types.NamespacedName{Name: "argocd-cm", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdCM, Namespace: argocdAppsNs}
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookup, cm)).To(Succeed())
@@ -582,7 +582,7 @@ var _ = Describe("Argocduser controller", func() {
 		It("Should update the `argocd-secret` Secret and update required accounts", func() {
 			By("Verifying passwords are updated in argocd-secret")
 			sec := &corev1.Secret{}
-			lookup := types.NamespacedName{Name: "argocd-secret", Namespace: argocdAppsNs}
+			lookup := types.NamespacedName{Name: testArgocdSecret, Namespace: argocdAppsNs}
 
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, lookup, sec)).To(Succeed())

--- a/internal/controller/common_unit_test.go
+++ b/internal/controller/common_unit_test.go
@@ -10,7 +10,12 @@ import (
 	"github.com/snapp-incubator/argocd-complementary-operator/pkg/nameset"
 )
 
-const testSourceNS = "source-ns"
+const (
+	testSourceNS = "source-ns"
+	testTeamA    = "team-a"
+	testTeamB    = "team-b"
+	testTeamC    = "team-c"
+)
 
 func mustUnsetenv(t *testing.T, key string) {
 	t.Helper()
@@ -184,38 +189,38 @@ func TestIsTeamClusterAdmin(t *testing.T) {
 	}{
 		{
 			name:     "team is in the list",
-			team:     "team-a",
-			list:     []string{"team-a", "team-b"},
+			team:     testTeamA,
+			list:     []string{testTeamA, testTeamB},
 			expected: true,
 		},
 		{
 			name:     "team is not in the list",
-			team:     "team-c",
-			list:     []string{"team-a", "team-b"},
+			team:     testTeamC,
+			list:     []string{testTeamA, testTeamB},
 			expected: false,
 		},
 		{
 			name:     "empty list",
-			team:     "team-a",
+			team:     testTeamA,
 			list:     []string{},
 			expected: false,
 		},
 		{
 			name:     "nil list",
-			team:     "team-a",
+			team:     testTeamA,
 			list:     nil,
 			expected: false,
 		},
 		{
 			name:     "empty team name",
 			team:     "",
-			list:     []string{"team-a"},
+			list:     []string{testTeamA},
 			expected: false,
 		},
 		{
 			name:     "single item list matching",
-			team:     "team-a",
-			list:     []string{"team-a"},
+			team:     testTeamA,
+			list:     []string{testTeamA},
 			expected: true,
 		},
 	}
@@ -495,13 +500,13 @@ func TestLabelToProjects(t *testing.T) {
 	}{
 		{
 			name:     "single project",
-			label:    "team-a",
-			expected: []string{"team-a"},
+			label:    testTeamA,
+			expected: []string{testTeamA},
 		},
 		{
 			name:     "multiple projects separated by dots",
 			label:    "team-a.team-b.team-c",
-			expected: []string{"team-a", "team-b", "team-c"},
+			expected: []string{testTeamA, testTeamB, testTeamC},
 		},
 		{
 			name:     "empty string",
@@ -511,17 +516,17 @@ func TestLabelToProjects(t *testing.T) {
 		{
 			name:     "trailing dots ignored",
 			label:    "team-a.",
-			expected: []string{"team-a"},
+			expected: []string{testTeamA},
 		},
 		{
 			name:     "leading dots ignored",
 			label:    ".team-a",
-			expected: []string{"team-a"},
+			expected: []string{testTeamA},
 		},
 		{
 			name:     "consecutive dots ignored",
 			label:    "team-a..team-b",
-			expected: []string{"team-a", "team-b"},
+			expected: []string{testTeamA, testTeamB},
 		},
 		{
 			name:     "only dots",

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -53,6 +53,9 @@ const (
 	timeout      = time.Second * 30
 	interval     = time.Millisecond * 100
 	argocdAppsNs = "user-argocd"
+
+	testArgocdCM     = "argocd-cm"
+	testArgocdSecret = "argocd-secret"
 )
 
 var (
@@ -153,7 +156,7 @@ var _ = BeforeSuite(func() {
 	By("Creating argocd-cm ConfigMap")
 	argocdCM := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-cm",
+			Name:      testArgocdCM,
 			Namespace: argocdAppsNs,
 		},
 		Data: map[string]string{
@@ -161,14 +164,14 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(k8sClient.Create(ctx, argocdCM)).Should(Succeed())
-	argocdCMLookup := types.NamespacedName{Name: "argocd-cm", Namespace: argocdAppsNs}
+	argocdCMLookup := types.NamespacedName{Name: testArgocdCM, Namespace: argocdAppsNs}
 	Expect(k8sClient.Get(ctx, argocdCMLookup, argocdCM)).Should(Succeed())
 
 	// Create argocd-secret Secret
 	By("Creating argocd-secret Secret")
 	argocdSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "argocd-secret",
+			Name:      testArgocdSecret,
 			Namespace: argocdAppsNs,
 		},
 		Data: map[string][]byte{
@@ -176,7 +179,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 	Expect(k8sClient.Create(ctx, argocdSecret)).Should(Succeed())
-	argocdSecretLookup := types.NamespacedName{Name: "argocd-secret", Namespace: argocdAppsNs}
+	argocdSecretLookup := types.NamespacedName{Name: testArgocdSecret, Namespace: argocdAppsNs}
 	Expect(k8sClient.Get(ctx, argocdSecretLookup, argocdSecret)).Should(Succeed())
 
 	// Wait for cache to sync before running tests


### PR DESCRIPTION
golangci-lint `latest` advanced to v2.12.2 and now flags repeated string literals via `goconst`, turning the lint job red on `main` (and on every PR).

Extract the repeated literals into constants:
- **controller_test** package: `testArgocdCM` / `testArgocdSecret` (defined in suite_test.go; the two files are `package controller_test` so they can't use the unexported package consts).
- **controller** package: `testTeamA` / `testTeamB` / `testTeamC` (common_unit_test.go).

No behavior change. Verified locally: `golangci-lint run ./...` → 0 issues; tests compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)