### PR TITLE
fix: pull kube-rbac-proxy from quay.io (gcr mirror deprecated)

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -9,8 +9,12 @@ spec:
   template:
     spec:
       containers:
+      # kube-rbac-proxy is pulled from quay.io (brancz, the upstream maintainer):
+      # the gcr.io/kubebuilder mirror was deprecated and no longer serves these
+      # tags, and the SnappCloud Harbor `gcr` proxy-cache can't fetch them. The
+      # `quay` proxy-cache resolves this image fine.
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.16.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
## Problem

The `kube-rbac-proxy` sidecar references `gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0`. That kubebuilder gcr mirror is deprecated and no longer serves these tags, and SnappCloud's Harbor `gcr` **proxy-cache** project can't fetch them (push is also denied — it's a proxy project). Result: on any node without a cached copy, the sidecar pull hangs and the pod never becomes Ready. This blocked the v0.5.0 rollout (the old pod only runs because the image was node-cached 129 days ago).

Evidence (in-cluster):
```
Failed to pull gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0:
  mirrors.dc.snappcloud.io/gcr/... : resource not found
  gcr.io (direct): connection timed out
```

## Fix

Point the sidecar at `quay.io/brancz/kube-rbac-proxy:v0.16.0` — the upstream maintainer's canonical registry. Verified the Harbor `quay` proxy-cache resolves it (`crane manifest mirrors.dc.snappcloud.io/quay/brancz/kube-rbac-proxy:v0.16.0` → OK), and 4400+ in-cluster containers already pull from quay. Same image version, no behavior change.

This is a `config/default` manifest change, synced directly by the `spcld-argocd-complementary-operator` Argo app — no new operator image/tag needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)