### PR TITLE
fix: raise manager memory limit to 2Gi (OOMKilled crash-loop)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,9 +50,12 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 512Mi
+              # 512Mi was too small for the cold-start informer cache spike on
+              # large clusters (cluster-wide Secret/ConfigMap/Namespace caches),
+              # causing OOMKilled crash-loops on a fresh pod. Bumped for headroom.
+              memory: 2Gi
             requests:
               cpu: 100m
-              memory: 128Mi
+              memory: 512Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
## Problem

A fresh manager pod **OOMKilled crash-loops** (43 restarts observed): `512Mi` can't hold the cold-start informer cache spike — the controllers watch Secrets/ConfigMaps/Namespaces cluster-wide, and on a large (225-node) cluster the initial LIST exceeds the limit. The long-running pod only survived because its cache was warmed when the cluster was smaller; any restart now crash-loops.

Manager `lastState.terminated`: `reason=OOMKilled exitCode=137`, crash begins right after cache/leader-election startup, before any reconcile.

## Fix

Raise the manager limit `512Mi → 2Gi` and request `128Mi → 512Mi`. Config-only; synced by the `spcld-argocd-complementary-operator` Argo app.

(Follow-up worth considering separately: scope the Secret/ConfigMap watches with field/namespace selectors to cut steady-state memory.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)