### PR TITLE
fix: raise manager memory limit to 4Gi (OOM at 2Gi)

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,10 +50,12 @@ spec:
           resources:
             limits:
               cpu: 500m
-              # 512Mi was too small for the cold-start informer cache spike on
-              # large clusters (cluster-wide Secret/ConfigMap/Namespace caches),
-              # causing OOMKilled crash-loops on a fresh pod. Bumped for headroom.
-              memory: 2Gi
+              # The controllers cache cluster-wide Secrets/ConfigMaps; on a
+              # cluster with ~33k secrets the cold-start LIST spike exceeded
+              # 512Mi (and 2Gi), OOMKilling a fresh pod. 4Gi covers the spike.
+              # TODO: scope the cache (cache.Options.ByObject -> user-argocd)
+              # so this no longer scales with total cluster secret count.
+              memory: 4Gi
             requests:
               cpu: 100m
               memory: 512Mi


### PR DESCRIPTION
2Gi still OOMKilled the manager. The controllers cache cluster-wide Secrets; with ~33,493 secrets in the cluster the cold-start LIST spikes past 2Gi. Bump to 4Gi.

Follow-up (separate): scope the informer cache with `cache.Options.ByObject` to `user-argocd` so memory no longer scales with total cluster secret count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)