### PR TITLE
chore: release v0.5.1 (scoped Secret/ConfigMap caches)

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/snapp-incubator/argocd-complementary-operator
-  newTag: 0.5.0
+  newTag: 0.5.1


### PR DESCRIPTION
Bumps the deployed image to 0.5.1, which includes the cache-scoping fix (#140) that bounds the manager's memory. Tag v0.5.1 will be cut from main after merge to build the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)