### PR TITLE
chore: right-size manager memory back to 512Mi/128Mi

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,14 +50,12 @@ spec:
           resources:
             limits:
               cpu: 500m
-              # The controllers cache cluster-wide Secrets/ConfigMaps; on a
-              # cluster with ~33k secrets the cold-start LIST spike exceeded
-              # 512Mi (and 2Gi), OOMKilling a fresh pod. 4Gi covers the spike.
-              # TODO: scope the cache (cache.Options.ByObject -> user-argocd)
-              # so this no longer scales with total cluster secret count.
-              memory: 4Gi
+              # Since v0.5.1 the Secret/ConfigMap caches are scoped to
+              # user-argocd (cache.Options.ByObject), so steady-state usage is
+              # ~30Mi regardless of cluster size. 512Mi is ample headroom.
+              memory: 512Mi
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 128Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10


### PR DESCRIPTION
The 4Gi limit / 512Mi request was a stopgap for the OOM crash-loop. Since v0.5.1 scoped the Secret/ConfigMap caches to `user-argocd`, steady-state usage is ~30Mi (verified in-cluster). Return to the original 512Mi limit / 128Mi request.

Config-only; synced by the `spcld-argocd-complementary-operator` Argo app, no new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)