### PR TITLE
chore: release v0.5.2 (configurable USER_ARGOCD_NAMESPACE)

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/snapp-incubator/argocd-complementary-operator
-  newTag: 0.5.1
+  newTag: 0.5.2


### PR DESCRIPTION
Bumps the deployed image to 0.5.2 (configurable managed namespace, #143). Tag v0.5.2 cut from main after merge builds the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)