### PR TITLE
feat: grant restart action to the sync project role (v0.5.3)

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/snapp-incubator/argocd-complementary-operator
-  newTag: 0.5.2
+  newTag: 0.5.3

--- a/internal/controller/common_unit_test.go
+++ b/internal/controller/common_unit_test.go
@@ -374,6 +374,9 @@ func TestCreateAppProjStructure(t *testing.T) {
 		expectedPolicies := []string{
 			"p, proj:team-x:team-x-sync, applications, get, team-x/*, allow",
 			"p, proj:team-x:team-x-sync, applications, sync, team-x/*, allow",
+			"p, proj:team-x:team-x-sync, applications, action/apps/Deployment/restart, team-x/*, allow",
+			"p, proj:team-x:team-x-sync, applications, action/apps/StatefulSet/restart, team-x/*, allow",
+			"p, proj:team-x:team-x-sync, applications, action/apps/DaemonSet/restart, team-x/*, allow",
 			"p, proj:team-x:team-x-sync, repositories, get, team-x/*, allow",
 			"p, proj:team-x:team-x-sync, logs, get, team-x/*, allow",
 		}

--- a/internal/controller/controller_common.go
+++ b/internal/controller/controller_common.go
@@ -173,6 +173,9 @@ func createAppProj(team string) *argov1alpha1.AppProject {
 					Policies: []string{
 						"p, proj:" + team + ":" + team + "-sync, applications, get, " + team + "/*, allow",
 						"p, proj:" + team + ":" + team + "-sync, applications, sync, " + team + "/*, allow",
+						"p, proj:" + team + ":" + team + "-sync, applications, action/apps/Deployment/restart, " + team + "/*, allow",
+						"p, proj:" + team + ":" + team + "-sync, applications, action/apps/StatefulSet/restart, " + team + "/*, allow",
+						"p, proj:" + team + ":" + team + "-sync, applications, action/apps/DaemonSet/restart, " + team + "/*, allow",
 						"p, proj:" + team + ":" + team + "-sync, repositories, get, " + team + "/*, allow",
 						"p, proj:" + team + ":" + team + "-sync, logs, get, " + team + "/*, allow",
 					},


### PR DESCRIPTION
## What

The team `-sync` project role now grants a **restart resource-action** in addition to `applications, sync`, so sync-tier devs can restart their own workloads (the ArgoCD **Restart** button) without needing full `admin`.

Added policies (per team, scoped to `<team>/*`):

```
applications, action/apps/Deployment/restart
applications, action/apps/StatefulSet/restart
applications, action/apps/DaemonSet/restart
```

Kept deliberately narrower than `action/*` — pause/resume/retry stay admin-only.

## Why

Box devs already on the `sync` tier (box project on box-teh-2 / okd4-teh-1) need to restart deployments themselves. Extending the tier is the clean path vs. bumping them to `admin`.

## Blast radius

Applies to the `-sync` role of **every team on every cluster** the operator manages — inherent to changing the tier definition. `admin` and `view` are untouched. AppProject policies regenerate on the operator's next reconcile after upgrade; no `argocd-complementary` values changes needed.

## Tests

- Updated the `sync role policies` unit test to assert the new lines.
- `go build ./internal/...` ✓  ·  `go test ./internal/controller/` → `ok`

## Release

Bumps `config/manager/kustomization.yaml` newTag → `0.5.3`. Tag `v0.5.3` after merge triggers the CI docker build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)