### PR TITLE
feat: report and optionally prune undeclared OpenShift Group members

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,9 +148,23 @@ truth: undeclared members are pruned (a `GroupMembersPruned` Event records who),
 out-of-band edits are reverted on the next reconcile — the operator watches the
 Groups — and the Groups are deleted with their `ArgocdUser`.
 
-Roll it out per cluster, and only once the gauge shows the declarations match
-reality. The same Groups are often referenced by namespace `RoleBinding`s, so
-pruning can revoke `oc`/`kubectl` access as well as the ArgoCD role.
+Because that env var applies to every project on the cluster at once, a single
+`ArgocdUser` can override it in either direction:
+
+```yaml
+metadata:
+  annotations:
+    argocd.snappcloud.io/authoritative-groups: "true"
+```
+
+So one project can be tightened while the rest of the cluster keeps merging, or
+one project exempted on a cluster that is otherwise strict. An absent or
+unparseable annotation falls back to the env var.
+
+Roll it out project by project, and only once the gauge shows a project's
+declarations match reality. The same Groups are often referenced by namespace
+`RoleBinding`s, so pruning can revoke `oc`/`kubectl` access as well as the
+ArgoCD role.
 
 ### Cleanup
 
@@ -173,7 +187,7 @@ When an `ArgocdUser` is deleted, the operator automatically cleans up:
 | `PUBLIC_REPOS` | Comma-separated list of public repositories available to all projects |
 | `CLUSTER_ADMIN_TEAMS` | Comma-separated list of teams with cluster-admin privileges |
 | `USER_ARGOCD_NAMESPACE` | Namespace holding the managed AppProjects and the argocd static-user ConfigMap/Secret. Also scopes the manager's Secret/ConfigMap informer caches. Defaults to `user-argocd`. |
-| `GROUP_MEMBERSHIP_AUTHORITATIVE` | Makes the `ArgocdUser` spec the sole source of truth for its OpenShift Groups: prunes undeclared members and deletes the Groups on cleanup. Defaults to `false`, which merges membership and only reports drift. See [Group membership](#group-membership). |
+| `GROUP_MEMBERSHIP_AUTHORITATIVE` | Cluster-wide default for whether the `ArgocdUser` spec is the sole source of truth for its OpenShift Groups: prunes undeclared members and deletes the Groups on cleanup. Defaults to `false`, which merges membership and only reports drift. Overridable per project with the `argocd.snappcloud.io/authoritative-groups` annotation. See [Group membership](#group-membership). |
 
 ## Instructions
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ This creates:
    - `team-a-view` - contains view users
    - `team-a-sync` - contains sync users
 
+### Group membership
+
+The AppProject roles are bound to those OpenShift Groups, so a Group's members
+are the people who actually hold the role — removing a name from the
+`ArgocdUser` spec is not by itself a revocation.
+
+By default membership is **merged**: declared users are added, and members added
+out-of-band (`oc adm groups add-users`, a Group predating the CR, a name deleted
+from the spec after the fact) stay. Those extras are reported rather than
+removed:
+
+- a log line on every reconcile of the owning `ArgocdUser`
+- an `UndeclaredGroupMembers` warning Event on the `ArgocdUser`
+  (`kubectl describe argocduser team-a`)
+- the `argocduser_group_undeclared_members{argocduser,role,group}` gauge
+
+Set `GROUP_MEMBERSHIP_AUTHORITATIVE=true` to make the spec the sole source of
+truth: undeclared members are pruned (a `GroupMembersPruned` Event records who),
+out-of-band edits are reverted on the next reconcile — the operator watches the
+Groups — and the Groups are deleted with their `ArgocdUser`.
+
+Roll it out per cluster, and only once the gauge shows the declarations match
+reality. The same Groups are often referenced by namespace `RoleBinding`s, so
+pruning can revoke `oc`/`kubectl` access as well as the ArgoCD role.
+
 ### Cleanup
 
 When an `ArgocdUser` is deleted, the operator automatically cleans up:
@@ -135,7 +160,9 @@ When an `ArgocdUser` is deleted, the operator automatically cleans up:
 - ConfigMap entries for static users
 - Secret entries for passwords
 - ClusterRole and ClusterRoleBinding (via OwnerReferences)
-- ~~OpenShift Groups~~ (Currently Disabled)
+- OpenShift Groups (only when `GROUP_MEMBERSHIP_AUTHORITATIVE=true`; otherwise
+  they are left behind, since a merged Group may hold members this operator
+  never granted)
 
 ## Configuration
 
@@ -146,6 +173,7 @@ When an `ArgocdUser` is deleted, the operator automatically cleans up:
 | `PUBLIC_REPOS` | Comma-separated list of public repositories available to all projects |
 | `CLUSTER_ADMIN_TEAMS` | Comma-separated list of teams with cluster-admin privileges |
 | `USER_ARGOCD_NAMESPACE` | Namespace holding the managed AppProjects and the argocd static-user ConfigMap/Secret. Also scopes the manager's Secret/ConfigMap informer caches. Defaults to `user-argocd`. |
+| `GROUP_MEMBERSHIP_AUTHORITATIVE` | Makes the `ArgocdUser` spec the sole source of truth for its OpenShift Groups: prunes undeclared members and deletes the Groups on cleanup. Defaults to `false`, which merges membership and only reports drift. See [Group membership](#group-membership). |
 
 ## Instructions
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -34,6 +34,14 @@ spec:
             # Defaults to user-argocd if unset; set here to make it explicit.
             - name: USER_ARGOCD_NAMESPACE
               value: user-argocd
+            # Whether the ArgocdUser spec is the sole source of truth for the
+            # OpenShift Groups this operator manages. Left false so membership
+            # is merged (the historical behaviour) and drift is only reported;
+            # flip to "true" per cluster once the declarations match reality —
+            # these Groups can also back namespace RoleBindings, so pruning
+            # revokes cluster access as well as the ArgoCD role.
+            - name: GROUP_MEMBERSHIP_AUTHORITATIVE
+              value: "false"
           envFrom:
             - configMapRef:
                 name: public-repos

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/openshift/api v0.0.0-20260105154426-319dc2e49203
+	github.com/prometheus/client_golang v1.22.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/crypto v0.47.0
 	k8s.io/api v0.31.14
@@ -102,7 +103,6 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.22.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect

--- a/internal/controller/argocduser_controller.go
+++ b/internal/controller/argocduser_controller.go
@@ -55,9 +55,11 @@ type ArgocdUserReconciler struct {
 	Recorder          record.EventRecorder
 	mu                sync.Mutex
 	GroupCRDInstalled bool
-	// GroupMembershipAuthoritative makes the ArgocdUser spec the sole source of
-	// truth for the OpenShift Groups this operator manages. Resolved from the
-	// GROUP_MEMBERSHIP_AUTHORITATIVE env var in SetupWithManager; see
+	// GroupMembershipAuthoritative is the cluster-wide default for whether the
+	// ArgocdUser spec is the sole source of truth for the OpenShift Groups this
+	// operator manages. Resolved from the GROUP_MEMBERSHIP_AUTHORITATIVE env var
+	// in SetupWithManager, and overridable per ArgocdUser through the
+	// argocd.snappcloud.io/authoritative-groups annotation. See
 	// groupMembershipAuthoritative for what it changes.
 	GroupMembershipAuthoritative bool
 }
@@ -554,23 +556,24 @@ func (r *ArgocdUserReconciler) ReconcileArgoUsersGroup(ctx context.Context, argo
 		}
 	}
 
-	desiredUsers, undeclaredUsers := desiredGroupUsers(group.Users, argoUsers, r.GroupMembershipAuthoritative)
+	authoritative := groupMembershipAuthoritativeFor(argocduser.Annotations, r.GroupMembershipAuthoritative)
+	desiredUsers, undeclaredUsers := desiredGroupUsers(group.Users, argoUsers, authoritative)
 	undeclaredGroupMembers.WithLabelValues(argocduser.Name, roleName, groupName).Set(float64(len(undeclaredUsers)))
 
 	if len(undeclaredUsers) > 0 {
-		if r.GroupMembershipAuthoritative {
+		if authoritative {
 			logger.Info("Removing members that the ArgocdUser does not declare",
 				"Group", groupName, "prunedCount", len(undeclaredUsers), "pruned", undeclaredUsers)
 			r.eventf(argocduser, corev1.EventTypeNormal, "GroupMembersPruned",
 				"Removed %d undeclared member(s) from Group %s: %s",
 				len(undeclaredUsers), groupName, summarizeUsers(undeclaredUsers, eventUserSampleSize))
 		} else {
-			logger.Info("Group holds members the ArgocdUser does not declare; keeping them because "+groupMembershipAuthoritativeEnv+" is false",
+			logger.Info("Group holds members the ArgocdUser does not declare; keeping them because group membership is not authoritative here",
 				"Group", groupName, "undeclaredCount", len(undeclaredUsers), "undeclared", undeclaredUsers)
 			r.eventf(argocduser, corev1.EventTypeWarning, "UndeclaredGroupMembers",
-				"Group %s holds %d member(s) this ArgocdUser does not declare: %s. They keep the %s role until %s=true.",
+				"Group %s holds %d member(s) this ArgocdUser does not declare: %s. They keep the %s role until %s=true or the %s annotation is set.",
 				groupName, len(undeclaredUsers), summarizeUsers(undeclaredUsers, eventUserSampleSize),
-				roleName, groupMembershipAuthoritativeEnv)
+				roleName, groupMembershipAuthoritativeEnv, GroupMembershipAuthoritativeAnnotation)
 		}
 	}
 
@@ -612,7 +615,7 @@ func (r *ArgocdUserReconciler) cleanupResources(ctx context.Context, argocduser 
 	}
 
 	// 4. Delete Groups (only when this operator exclusively owns them)
-	if err := r.deleteGroups(ctx, name); err != nil {
+	if err := r.deleteGroups(ctx, argocduser); err != nil {
 		return err
 	}
 
@@ -625,17 +628,18 @@ func (r *ArgocdUserReconciler) cleanupResources(ctx context.Context, argocduser 
 // Only safe when the operator owns Group membership outright: with merged
 // membership a Group can hold people this ArgocdUser never declared, and
 // deleting it would revoke access the operator never granted. So this is a
-// no-op unless GroupMembershipAuthoritative is set, which is also why the
-// Groups have historically been left behind.
-func (r *ArgocdUserReconciler) deleteGroups(ctx context.Context, name string) error {
+// no-op unless membership is authoritative for this ArgocdUser, which is also
+// why the Groups have historically been left behind.
+func (r *ArgocdUserReconciler) deleteGroups(ctx context.Context, argocduser *argocduserv1alpha1.ArgocdUser) error {
 	logger := log.FromContext(ctx)
+	name := argocduser.Name
 
 	if !r.GroupCRDInstalled {
 		logger.Info("Group CRD not registered in scheme, skipping group cleanup")
 		return nil
 	}
-	if !r.GroupMembershipAuthoritative {
-		logger.Info("Leaving Groups in place because "+groupMembershipAuthoritativeEnv+" is false", "ArgocdUser", name)
+	if !groupMembershipAuthoritativeFor(argocduser.Annotations, r.GroupMembershipAuthoritative) {
+		logger.Info("Leaving Groups in place because group membership is not authoritative here", "ArgocdUser", name)
 		return nil
 	}
 

--- a/internal/controller/argocduser_controller.go
+++ b/internal/controller/argocduser_controller.go
@@ -36,6 +36,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
+	"k8s.io/client-go/tools/record"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -50,8 +52,23 @@ var gvk = userv1.GroupVersion.WithKind("Group")
 type ArgocdUserReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
+	Recorder          record.EventRecorder
 	mu                sync.Mutex
 	GroupCRDInstalled bool
+	// GroupMembershipAuthoritative makes the ArgocdUser spec the sole source of
+	// truth for the OpenShift Groups this operator manages. Resolved from the
+	// GROUP_MEMBERSHIP_AUTHORITATIVE env var in SetupWithManager; see
+	// groupMembershipAuthoritative for what it changes.
+	GroupMembershipAuthoritative bool
+}
+
+// eventf records an Event on the ArgocdUser, tolerating a nil recorder so the
+// reconciler stays usable when constructed directly (as the tests do).
+func (r *ArgocdUserReconciler) eventf(argocduser *argocduserv1alpha1.ArgocdUser, eventType, reason, messageFmt string, args ...interface{}) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(argocduser, eventType, reason, messageFmt, args...)
 }
 
 //+kubebuilder:rbac:groups=argocd.snappcloud.io,resources=argocdusers,verbs=get;list;watch;create;update;patch;delete
@@ -396,7 +413,7 @@ func (r *ArgocdUserReconciler) reconcileArgocdStaticUser(ctx context.Context, ar
 		logger.Error(err, "Failed to create argocd static user configs", "ArgocdUser", argocduser.Name, "role", "admin")
 		return err
 	}
-	if err := r.AddArgoUsersToGroup(ctx, argocduser, "admin", argocduser.Spec.Admin.Users); err != nil {
+	if err := r.ReconcileArgoUsersGroup(ctx, argocduser, "admin", argocduser.Spec.Admin.Users); err != nil {
 		logger.Error(err, "Failed to update OpenShift groups for Argocduser", "ArgocdUser", argocduser.Name, "role", "admin")
 		return err
 	}
@@ -406,7 +423,7 @@ func (r *ArgocdUserReconciler) reconcileArgocdStaticUser(ctx context.Context, ar
 		logger.Error(err, "Failed to create argocd static user configs", "ArgocdUser", argocduser.Name, "role", "view")
 		return err
 	}
-	if err := r.AddArgoUsersToGroup(ctx, argocduser, "view", argocduser.Spec.View.Users); err != nil {
+	if err := r.ReconcileArgoUsersGroup(ctx, argocduser, "view", argocduser.Spec.View.Users); err != nil {
 		logger.Error(err, "Failed to update OpenShift groups for Argocduser", "ArgocdUser", argocduser.Name, "role", "view")
 		return err
 	}
@@ -416,7 +433,7 @@ func (r *ArgocdUserReconciler) reconcileArgocdStaticUser(ctx context.Context, ar
 		logger.Error(err, "Failed to create argocd static user configs", "ArgocdUser", argocduser.Name, "role", "sync")
 		return err
 	}
-	if err := r.AddArgoUsersToGroup(ctx, argocduser, "sync", argocduser.Spec.Sync.Users); err != nil {
+	if err := r.ReconcileArgoUsersGroup(ctx, argocduser, "sync", argocduser.Spec.Sync.Users); err != nil {
 		logger.Error(err, "Failed to update OpenShift groups for Argocduser", "ArgocdUser", argocduser.Name, "role", "sync")
 		return err
 	}
@@ -500,7 +517,10 @@ func (r *ArgocdUserReconciler) UpdateUserArgocdConfig(ctx context.Context, argoc
 	return nil
 }
 
-func (r *ArgocdUserReconciler) AddArgoUsersToGroup(ctx context.Context, argocduser *argocduserv1alpha1.ArgocdUser, roleName string, argoUsers []string) error {
+// ReconcileArgoUsersGroup brings the OpenShift Group backing one ArgocdUser role
+// in line with the users declared on the spec. Undeclared members are always
+// reported; whether they are removed depends on GroupMembershipAuthoritative.
+func (r *ArgocdUserReconciler) ReconcileArgoUsersGroup(ctx context.Context, argocduser *argocduserv1alpha1.ArgocdUser, roleName string, argoUsers []string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	logger := log.FromContext(ctx)
@@ -512,19 +532,20 @@ func (r *ArgocdUserReconciler) AddArgoUsersToGroup(ctx context.Context, argocdus
 	}
 
 	groupName := argocduser.Name + "-" + roleName
-	desiredGroup := &userv1.Group{
-		ObjectMeta: metav1.ObjectMeta{Name: groupName},
-		Users:      argoUsers,
-	}
 	group := &userv1.Group{}
 	err := r.Get(ctx, types.NamespacedName{Name: groupName}, group)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			desiredGroup := &userv1.Group{
+				ObjectMeta: metav1.ObjectMeta{Name: groupName},
+				Users:      argoUsers,
+			}
 			logger.Info("Creating the group", "Group", groupName)
 			if err = r.Create(ctx, desiredGroup); err != nil {
 				logger.Error(err, "Failed to create group", "Group", groupName)
 				return err
 			}
+			undeclaredGroupMembers.WithLabelValues(argocduser.Name, roleName, groupName).Set(0)
 			logger.Info("Successfully created Group", "Group", groupName)
 			return nil
 		} else {
@@ -533,20 +554,38 @@ func (r *ArgocdUserReconciler) AddArgoUsersToGroup(ctx context.Context, argocdus
 		}
 	}
 
-	mergedUsers := mergeStringSlices(group.Users, argoUsers)
+	desiredUsers, undeclaredUsers := desiredGroupUsers(group.Users, argoUsers, r.GroupMembershipAuthoritative)
+	undeclaredGroupMembers.WithLabelValues(argocduser.Name, roleName, groupName).Set(float64(len(undeclaredUsers)))
+
+	if len(undeclaredUsers) > 0 {
+		if r.GroupMembershipAuthoritative {
+			logger.Info("Removing members that the ArgocdUser does not declare",
+				"Group", groupName, "prunedCount", len(undeclaredUsers), "pruned", undeclaredUsers)
+			r.eventf(argocduser, corev1.EventTypeNormal, "GroupMembersPruned",
+				"Removed %d undeclared member(s) from Group %s: %s",
+				len(undeclaredUsers), groupName, summarizeUsers(undeclaredUsers, eventUserSampleSize))
+		} else {
+			logger.Info("Group holds members the ArgocdUser does not declare; keeping them because "+groupMembershipAuthoritativeEnv+" is false",
+				"Group", groupName, "undeclaredCount", len(undeclaredUsers), "undeclared", undeclaredUsers)
+			r.eventf(argocduser, corev1.EventTypeWarning, "UndeclaredGroupMembers",
+				"Group %s holds %d member(s) this ArgocdUser does not declare: %s. They keep the %s role until %s=true.",
+				groupName, len(undeclaredUsers), summarizeUsers(undeclaredUsers, eventUserSampleSize),
+				roleName, groupMembershipAuthoritativeEnv)
+		}
+	}
 
 	// Only update if the users changed
-	bothEmpty := (len(group.Users) == 0 && len(mergedUsers) == 0)
-	if !bothEmpty && !reflect.DeepEqual(group.Users, mergedUsers) {
-		logger.Info("Updating group with merged users", "Group", groupName, "existingCount", len(group.Users), "newCount", len(mergedUsers))
-		logger.Info("Users differ", "existing", group.Users, "merged", mergedUsers)
-		group.Users = mergedUsers
+	bothEmpty := (len(group.Users) == 0 && len(desiredUsers) == 0)
+	if !bothEmpty && !reflect.DeepEqual(group.Users, desiredUsers) {
+		logger.Info("Updating group users", "Group", groupName, "existingCount", len(group.Users), "newCount", len(desiredUsers))
+		logger.Info("Users differ", "existing", group.Users, "desired", desiredUsers)
+		group.Users = desiredUsers
 		err = r.Update(ctx, group)
 		if err != nil {
 			logger.Error(err, "Failed to update group", "Group", groupName)
 			return err
 		}
-		logger.Info("Successfully updated group with merged users", "Group", groupName)
+		logger.Info("Successfully updated group users", "Group", groupName)
 	} else {
 		logger.Info("Group users already up to date, skipping update", "Group", groupName)
 	}
@@ -572,12 +611,47 @@ func (r *ArgocdUserReconciler) cleanupResources(ctx context.Context, argocduser 
 		return err
 	}
 
-	// 4. Delete Groups (if registered)
-	// if err := r.deleteGroups(ctx, name); err != nil {
-	//     return err
-	// }
+	// 4. Delete Groups (only when this operator exclusively owns them)
+	if err := r.deleteGroups(ctx, name); err != nil {
+		return err
+	}
 
 	logger.Info("Successfully cleaned up all resources", "ArgocdUser", name)
+	return nil
+}
+
+// deleteGroups removes the OpenShift Groups backing a deleted ArgocdUser.
+//
+// Only safe when the operator owns Group membership outright: with merged
+// membership a Group can hold people this ArgocdUser never declared, and
+// deleting it would revoke access the operator never granted. So this is a
+// no-op unless GroupMembershipAuthoritative is set, which is also why the
+// Groups have historically been left behind.
+func (r *ArgocdUserReconciler) deleteGroups(ctx context.Context, name string) error {
+	logger := log.FromContext(ctx)
+
+	if !r.GroupCRDInstalled {
+		logger.Info("Group CRD not registered in scheme, skipping group cleanup")
+		return nil
+	}
+	if !r.GroupMembershipAuthoritative {
+		logger.Info("Leaving Groups in place because "+groupMembershipAuthoritativeEnv+" is false", "ArgocdUser", name)
+		return nil
+	}
+
+	for _, roleName := range groupRoles {
+		groupName := name + "-" + roleName
+		group := &userv1.Group{ObjectMeta: metav1.ObjectMeta{Name: groupName}}
+		if err := r.Delete(ctx, group); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			logger.Error(err, "Failed to delete Group", "Group", groupName)
+			return err
+		}
+		undeclaredGroupMembers.DeleteLabelValues(name, roleName, groupName)
+		logger.Info("Removed Group", "Group", groupName)
+	}
 	return nil
 }
 
@@ -663,6 +737,12 @@ func (r *ArgocdUserReconciler) removeSecretEntries(ctx context.Context, name str
 // SetupWithManager sets up the controller with the Manager.
 func (r *ArgocdUserReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.GroupCRDInstalled = isCRDInstalled(mgr.GetConfig(), gvk)
+	r.GroupMembershipAuthoritative = groupMembershipAuthoritative()
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor("argocduser-controller")
+	}
+	mgr.GetLogger().Info("Group membership mode resolved",
+		"authoritative", r.GroupMembershipAuthoritative, "env", groupMembershipAuthoritativeEnv)
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&argocduserv1alpha1.ArgocdUser{}).

--- a/internal/controller/common_unit_test.go
+++ b/internal/controller/common_unit_test.go
@@ -15,6 +15,9 @@ const (
 	testTeamA    = "team-a"
 	testTeamB    = "team-b"
 	testTeamC    = "team-c"
+
+	testUndeclaredUser = "pouya@snapp-box.com"
+	testDeclaredUser   = "sina@snapp-box.com"
 )
 
 func mustUnsetenv(t *testing.T, key string) {
@@ -609,6 +612,154 @@ func TestLabelToProjects(t *testing.T) {
 				if !result.Contains(exp) {
 					t.Errorf("expected result to contain %q", exp)
 				}
+			}
+		})
+	}
+}
+
+func TestGroupMembershipAuthoritative(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		unset    bool
+		expected bool
+	}{
+		{name: "defaults to merge when unset", unset: true, expected: false},
+		{name: "empty is merge", value: "", expected: false},
+		{name: "true", value: "true", expected: true},
+		{name: "True", value: "True", expected: true},
+		{name: "1", value: "1", expected: true},
+		{name: "false", value: "false", expected: false},
+		{name: "garbage falls back to merge", value: "yes-please", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unset {
+				mustUnsetenv(t, groupMembershipAuthoritativeEnv)
+			} else {
+				t.Setenv(groupMembershipAuthoritativeEnv, tt.value)
+			}
+			if got := groupMembershipAuthoritative(); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestDesiredGroupUsers(t *testing.T) {
+	tests := []struct {
+		name               string
+		existing           []string
+		declared           []string
+		authoritative      bool
+		expectedDesired    []string
+		expectedUndeclared []string
+	}{
+		{
+			name:               "merge keeps a member the spec dropped",
+			existing:           []string{testUndeclaredUser, testDeclaredUser},
+			declared:           []string{testDeclaredUser},
+			authoritative:      false,
+			expectedDesired:    []string{testUndeclaredUser, testDeclaredUser},
+			expectedUndeclared: []string{testUndeclaredUser},
+		},
+		{
+			name:               "authoritative prunes a member the spec dropped",
+			existing:           []string{testUndeclaredUser, testDeclaredUser},
+			declared:           []string{testDeclaredUser},
+			authoritative:      true,
+			expectedDesired:    []string{testDeclaredUser},
+			expectedUndeclared: []string{testUndeclaredUser},
+		},
+		{
+			name:               "authoritative empties a group with nothing declared",
+			existing:           []string{"a", "b"},
+			declared:           nil,
+			authoritative:      true,
+			expectedDesired:    []string{},
+			expectedUndeclared: []string{"a", "b"},
+		},
+		{
+			name:               "merge keeps everyone when nothing is declared",
+			existing:           []string{"a", "b"},
+			declared:           nil,
+			authoritative:      false,
+			expectedDesired:    []string{"a", "b"},
+			expectedUndeclared: []string{"a", "b"},
+		},
+		{
+			name:               "declared members are added in both modes",
+			existing:           []string{"a"},
+			declared:           []string{"a", "b"},
+			authoritative:      false,
+			expectedDesired:    []string{"a", "b"},
+			expectedUndeclared: []string{},
+		},
+		{
+			name:               "no drift when they already match",
+			existing:           []string{"a", "b"},
+			declared:           []string{"b", "a"},
+			authoritative:      true,
+			expectedDesired:    []string{"a", "b"},
+			expectedUndeclared: []string{},
+		},
+		{
+			name:               "duplicates in the live group are reported once",
+			existing:           []string{"a", "a", "b"},
+			declared:           []string{"b"},
+			authoritative:      true,
+			expectedDesired:    []string{"b"},
+			expectedUndeclared: []string{"a"},
+		},
+		{
+			name:               "results are sorted",
+			existing:           []string{"z", "m"},
+			declared:           []string{"f", "a"},
+			authoritative:      true,
+			expectedDesired:    []string{"a", "f"},
+			expectedUndeclared: []string{"m", "z"},
+		},
+	}
+
+	assertEqual := func(t *testing.T, label string, got, expected []string) {
+		t.Helper()
+		if len(got) != len(expected) {
+			t.Fatalf("%s: expected %v, got %v", label, expected, got)
+		}
+		for i, v := range got {
+			if v != expected[i] {
+				t.Errorf("%s index %d: expected %q, got %q", label, i, expected[i], v)
+			}
+		}
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired, undeclared := desiredGroupUsers(tt.existing, tt.declared, tt.authoritative)
+			assertEqual(t, "desired", desired, tt.expectedDesired)
+			assertEqual(t, "undeclared", undeclared, tt.expectedUndeclared)
+		})
+	}
+}
+
+func TestSummarizeUsers(t *testing.T) {
+	tests := []struct {
+		name     string
+		users    []string
+		sample   int
+		expected string
+	}{
+		{name: "empty", users: nil, sample: 3, expected: ""},
+		{name: "under the sample size", users: []string{"a", "b"}, sample: 3, expected: "a, b"},
+		{name: "exactly the sample size", users: []string{"a", "b", "c"}, sample: 3, expected: "a, b, c"},
+		{name: "over the sample size", users: []string{"a", "b", "c", "d", "e"}, sample: 3, expected: "a, b, c and 2 more"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := summarizeUsers(tt.users, tt.sample); got != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
 	}

--- a/internal/controller/common_unit_test.go
+++ b/internal/controller/common_unit_test.go
@@ -18,6 +18,9 @@ const (
 
 	testUndeclaredUser = "pouya@snapp-box.com"
 	testDeclaredUser   = "sina@snapp-box.com"
+
+	testTrue  = "true"
+	testFalse = "false"
 )
 
 func mustUnsetenv(t *testing.T, key string) {
@@ -626,10 +629,10 @@ func TestGroupMembershipAuthoritative(t *testing.T) {
 	}{
 		{name: "defaults to merge when unset", unset: true, expected: false},
 		{name: "empty is merge", value: "", expected: false},
-		{name: "true", value: "true", expected: true},
+		{name: testTrue, value: testTrue, expected: true},
 		{name: "True", value: "True", expected: true},
 		{name: "1", value: "1", expected: true},
-		{name: "false", value: "false", expected: false},
+		{name: testFalse, value: testFalse, expected: false},
 		{name: "garbage falls back to merge", value: "yes-please", expected: false},
 	}
 
@@ -760,6 +763,55 @@ func TestSummarizeUsers(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := summarizeUsers(tt.users, tt.sample); got != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestGroupMembershipAuthoritativeFor(t *testing.T) {
+	tests := []struct {
+		name           string
+		annotations    map[string]string
+		clusterDefault bool
+		expected       bool
+	}{
+		{name: "no annotations falls back to the cluster default", annotations: nil, clusterDefault: true, expected: true},
+		{
+			name:           "unrelated annotations fall back",
+			annotations:    map[string]string{"other": testTrue},
+			clusterDefault: false,
+			expected:       false,
+		},
+		{
+			name:           "opts a single project in on a merging cluster",
+			annotations:    map[string]string{GroupMembershipAuthoritativeAnnotation: testTrue},
+			clusterDefault: false,
+			expected:       true,
+		},
+		{
+			name:           "exempts a single project on a strict cluster",
+			annotations:    map[string]string{GroupMembershipAuthoritativeAnnotation: testFalse},
+			clusterDefault: true,
+			expected:       false,
+		},
+		{
+			name:           "garbage falls back to the cluster default",
+			annotations:    map[string]string{GroupMembershipAuthoritativeAnnotation: "sure"},
+			clusterDefault: true,
+			expected:       true,
+		},
+		{
+			name:           "empty value falls back to the cluster default",
+			annotations:    map[string]string{GroupMembershipAuthoritativeAnnotation: ""},
+			clusterDefault: false,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := groupMembershipAuthoritativeFor(tt.annotations, tt.clusterDefault); got != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, got)
 			}
 		})
 	}

--- a/internal/controller/controller_common.go
+++ b/internal/controller/controller_common.go
@@ -24,9 +24,16 @@ const (
 	userArgocdSecret       = "argocd-secret"
 	argocdUserFinalizer    = "argocd.snappcloud.io/finalizer"
 
-	// groupMembershipAuthoritativeEnv toggles whether this operator exclusively
-	// owns the OpenShift Groups it manages. See groupMembershipAuthoritative.
+	// groupMembershipAuthoritativeEnv sets the cluster-wide default for whether
+	// this operator exclusively owns the OpenShift Groups it manages. See
+	// groupMembershipAuthoritative.
 	groupMembershipAuthoritativeEnv = "GROUP_MEMBERSHIP_AUTHORITATIVE"
+
+	// GroupMembershipAuthoritativeAnnotation overrides that default for a single
+	// ArgocdUser, in either direction — a strict project on an otherwise merging
+	// cluster, or an exemption on a strict one. See
+	// groupMembershipAuthoritativeFor.
+	GroupMembershipAuthoritativeAnnotation = "argocd.snappcloud.io/authoritative-groups"
 
 	// eventUserSampleSize caps how many usernames are named in an Event. Group
 	// drift routinely runs into the dozens and the Kubernetes event message
@@ -80,6 +87,22 @@ func groupMembershipAuthoritative() bool {
 	authoritative, err := strconv.ParseBool(os.Getenv(groupMembershipAuthoritativeEnv))
 	if err != nil {
 		return false
+	}
+	return authoritative
+}
+
+// groupMembershipAuthoritativeFor resolves the mode for a single ArgocdUser.
+// The annotation wins over the cluster-wide default whenever it is present and
+// parseable, which is what lets a cluster tighten one project at a time instead
+// of revoking every undeclared membership at once.
+func groupMembershipAuthoritativeFor(annotations map[string]string, clusterDefault bool) bool {
+	value, ok := annotations[GroupMembershipAuthoritativeAnnotation]
+	if !ok {
+		return clusterDefault
+	}
+	authoritative, err := strconv.ParseBool(value)
+	if err != nil {
+		return clusterDefault
 	}
 	return authoritative
 }

--- a/internal/controller/controller_common.go
+++ b/internal/controller/controller_common.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -23,6 +24,15 @@ const (
 	userArgocdSecret       = "argocd-secret"
 	argocdUserFinalizer    = "argocd.snappcloud.io/finalizer"
 
+	// groupMembershipAuthoritativeEnv toggles whether this operator exclusively
+	// owns the OpenShift Groups it manages. See groupMembershipAuthoritative.
+	groupMembershipAuthoritativeEnv = "GROUP_MEMBERSHIP_AUTHORITATIVE"
+
+	// eventUserSampleSize caps how many usernames are named in an Event. Group
+	// drift routinely runs into the dozens and the Kubernetes event message
+	// limit is around 1KiB, so the rest are reported as a count.
+	eventUserSampleSize = 5
+
 	// move a namespace into a argocd appproj using the label.
 	// for example argocd.snappcloud.io/appproj: snapppay means snapppay argo project
 	// can deploy resources into the labeled namespace.
@@ -32,6 +42,10 @@ const (
 	// in the labeled namespace can belongs to the snapppay argo project.
 	SourceLabel = "argocd.snappcloud.io/source"
 )
+
+// groupRoles are the roles this operator manages, one OpenShift Group each,
+// named "<argocduser>-<role>".
+var groupRoles = []string{"admin", "view", "sync"}
 
 // UserArgocdNS is the namespace holding the AppProjects and the argocd
 // static-user ConfigMap/Secret this operator manages. Configurable via the
@@ -46,6 +60,67 @@ func userArgocdNamespace() string {
 		return ns
 	}
 	return defaultUserArgocdNS
+}
+
+// groupMembershipAuthoritative reports whether the ArgocdUser spec is the sole
+// source of truth for the OpenShift Groups this operator manages.
+//
+// When false (the default) membership is merged: users declared on the spec are
+// added, and anyone added out-of-band — `oc adm groups add-users`, a Group that
+// predates the CR, a name removed from git after the fact — is left in place.
+// That is how a member removed from an ArgocdUser keeps their ArgoCD role
+// indefinitely, so the drift is reported via a log line, an Event, and the
+// argocduser_group_undeclared_members metric instead.
+//
+// When true the operator prunes undeclared members and deletes the Groups when
+// the ArgocdUser goes away. Turn it on only once the declarations match reality:
+// the same Groups can back namespace RoleBindings, so pruning revokes cluster
+// access as well as the ArgoCD role.
+func groupMembershipAuthoritative() bool {
+	authoritative, err := strconv.ParseBool(os.Getenv(groupMembershipAuthoritativeEnv))
+	if err != nil {
+		return false
+	}
+	return authoritative
+}
+
+// desiredGroupUsers computes the membership an OpenShift Group should end up
+// with, alongside the members it currently holds that the ArgocdUser does not
+// declare. The undeclared list is reported in both modes — it is the drift —
+// but only removed from the desired membership when authoritative is true.
+func desiredGroupUsers(existing, declared []string, authoritative bool) (desired, undeclared []string) {
+	declaredSet := nameset.New[string]()
+	for _, user := range declared {
+		declaredSet.Add(user)
+	}
+
+	undeclaredSet := nameset.New[string]()
+	for _, user := range existing {
+		if !declaredSet.Contains(user) {
+			undeclaredSet.Add(user)
+		}
+	}
+
+	undeclared = make([]string, 0, undeclaredSet.Len())
+	for user := range undeclaredSet.All() {
+		undeclared = append(undeclared, user)
+	}
+	slices.Sort(undeclared)
+
+	if authoritative {
+		// mergeStringSlices with nothing to merge is just sort + dedupe.
+		return mergeStringSlices(declared, nil), undeclared
+	}
+	return mergeStringSlices(existing, declared), undeclared
+}
+
+// summarizeUsers renders at most sample usernames, reporting the remainder as a
+// count so the result stays inside the Kubernetes event message limit.
+func summarizeUsers(users []string, sample int) string {
+	if len(users) <= sample {
+		return strings.Join(users, ", ")
+	}
+	return fmt.Sprintf("%s and %d more", strings.Join(users[:sample], ", "), len(users)-sample)
 }
 
 var NamespaceCache = &SafeNsCache{

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,27 @@
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// undeclaredGroupMembers tracks members that live in an OpenShift Group managed
+// by an ArgocdUser but are not declared on its spec — i.e. people who hold the
+// project's ArgoCD role (and, where the same Group backs a namespace
+// RoleBinding, cluster access) without git saying so.
+//
+// A non-zero value means the declaration and reality have diverged. In
+// authoritative mode the extra members are pruned and the gauge falls back to
+// zero; otherwise it keeps reporting the drift so it can be reconciled in git
+// before authoritative mode is switched on.
+var undeclaredGroupMembers = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "argocduser_group_undeclared_members",
+		Help: "Members of an ArgocdUser-managed OpenShift Group that are not declared on the ArgocdUser spec.",
+	},
+	[]string{"argocduser", "role", "group"},
+)
+
+func init() {
+	metrics.Registry.MustRegister(undeclaredGroupMembers)
+}


### PR DESCRIPTION
## Why

The AppProject roles this operator generates are bound to the OpenShift Groups it manages, so a Group's members are the people who actually hold the role. `AddArgoUsersToGroup` only ever unioned the declared users into the Group — it never removed anyone.

The consequence is that **removing a user from an `ArgocdUser` spec does not revoke anything.** On `box-teh-2` the `api-gateway` sync list was trimmed to a single user on 2026-08-03; the `api-gateway-sync` Group kept all 69 members, and one of the removed users successfully synced `krakend-nxp-private` on 2026-08-08 — five days later. A sweep of that cluster found **177 undeclared memberships across 11 Groups** (`api-gateway-sync` 1 declared / 69 live, `stg-sync` 15 / 54, several `*-sync` Groups 0 / 13).

## What

Default behaviour is unchanged — membership is still merged — but the drift is now visible:

- a log line on every reconcile of the owning `ArgocdUser`
- an `UndeclaredGroupMembers` warning Event (`kubectl describe argocduser <name>`)
- a new gauge `argocduser_group_undeclared_members{argocduser,role,group}`

`GROUP_MEMBERSHIP_AUTHORITATIVE=true` makes the spec the sole source of truth:

- undeclared members are pruned, recorded as a `GroupMembersPruned` Event
- out-of-band edits (`oc adm groups add-users`) are reverted on the next reconcile — the operator already watches these Groups, so this takes seconds
- the Groups are deleted with their `ArgocdUser`, re-enabling the `deleteGroups` step that has been commented out in `cleanupResources`

Because that env var applies to every project on a cluster at once, a single `ArgocdUser` can override it in either direction:

```yaml
metadata:
  annotations:
    argocd.snappcloud.io/authoritative-groups: "true"
```

So one project can be tightened while the rest of the cluster keeps merging, or one project exempted on a cluster that is otherwise strict.

## Rollout

Off by default, and deliberately incremental: the same Groups are referenced by namespace `RoleBinding`s in `platform/box-argocd-apps` (`okd4-teh-1/templates/namespaces/rolebindings.yaml` binds the `admin` ClusterRole to `<project>-admin`), so pruning revokes `oc`/`kubectl` access too, not just the ArgoCD role. Watch the gauge, fix the declarations in git, then opt projects in one at a time with the annotation before considering the cluster-wide env var.

## Tests

`make test` green (20 passed / 3 skipped), `golangci-lint` clean. New table-driven unit tests cover `desiredGroupUsers` in both modes (prune, keep, empty-declaration, dedupe, sorting), the env parsing, and the Event message truncation.

