### PR TITLE
fix: grant the operator RBAC to record Events

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,6 +20,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/internal/controller/argocduser_controller.go
+++ b/internal/controller/argocduser_controller.go
@@ -77,6 +77,10 @@ func (r *ArgocdUserReconciler) eventf(argocduser *argocduserv1alpha1.ArgocdUser,
 //+kubebuilder:rbac:groups=argocd.snappcloud.io,resources=argocdusers/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=argocd.snappcloud.io,resources=argocdusers/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// ArgocdUser is cluster-scoped, so its Events are recorded in the "default"
+// namespace — hence the cluster-wide grant rather than one scoped to the
+// operator's own namespace.
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=user.openshift.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
## Why

v0.6.0 reports Group membership drift through `UndeclaredGroupMembers` / `GroupMembersPruned` Events, but I never added an rbac marker for `events`. Every Event is rejected on box-teh-2:

```
E0810 10:14:43 event.go:359] "Server rejected event (will not retry!)"
  err="events \"box.18ca692879a9d9ac\" is forbidden: User
  \"system:serviceaccount:argocd-complementary-operator-system:argocd-complementary-operator-controller-manager\"
  cannot patch resource \"events\" in API group \"\" in the namespace \"default\""
```

Nothing was lost — the drift still shows in the operator logs and in `argocduser_group_undeclared_members` — but `kubectl describe argocduser <name>` showed none of it, and the rejection logged an error line on every reconcile of every drifted project.

## What

`//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch` plus the regenerated `config/rbac/role.yaml`.

`ArgocdUser` is cluster-scoped, so the recorder writes its Events into the `default` namespace — hence a cluster-wide grant rather than one scoped to the operator's namespace.

## Note for deployment

The ClusterRole is applied out-of-band on the clusters (the operator Deployment is not in GitOps), so the regenerated `role.yaml` has to be applied alongside the image bump — a new image alone will not fix it.